### PR TITLE
IMS-VT: Transmit static image when multitasking

### DIFF
--- a/InCallUI/src/com/android/incallui/CallButtonPresenter.java
+++ b/InCallUI/src/com/android/incallui/CallButtonPresenter.java
@@ -633,7 +633,7 @@ public class CallButtonPresenter extends Presenter<CallButtonPresenter.CallButto
         ui.showButton(BUTTON_SWITCH_CAMERA, isVideo && !sIsHideMe);
         // show hide me button only for active video calls
         ui.showButton(BUTTON_HIDE_ME, isCallActive && isVideo &&
-                QtiCallUtils.shallTransmitStaticImage(getUi().getContext()));
+                QtiCallUtils.shallShowStaticImageUi(getUi().getContext()));
         if (isVideo) {
             getUi().setVideoPaused(!VideoUtils.isTransmissionEnabled(call));
         }

--- a/InCallUI/src/com/android/incallui/QtiCallUtils.java
+++ b/InCallUI/src/com/android/incallui/QtiCallUtils.java
@@ -259,6 +259,13 @@ public class QtiCallUtils {
         return context != null && QtiImsExtUtils.useCustomVideoUi(context);
     }
 
+    public static boolean shallShowStaticImageUi(Context context) {
+        if (context == null) {
+            Log.w(context, "Context is null...");
+        }
+        return context != null && QtiImsExtUtils.shallShowStaticImageUi(context);
+    }
+
     /**
      * Checks the boolean flag in config file to figure out if transmitting static image
      * in a video call is enabled or not

--- a/InCallUI/src/com/android/incallui/VideoCallPresenter.java
+++ b/InCallUI/src/com/android/incallui/VideoCallPresenter.java
@@ -601,6 +601,17 @@ public class VideoCallPresenter extends Presenter<VideoCallPresenter.VideoCallUi
             return;
         }
 
+        if (!QtiCallUtils.shallShowStaticImageUi(mContext) &&
+             QtiCallUtils.shallTransmitStaticImage(mContext) &&
+             mIsInBackground &&
+             shallTransmitStaticImage() &&
+             !VideoUtils.isTransmissionEnabled(call) &&
+             mVideoCall != null) {
+            /* Unset the pause image when Tx is disabled for eg. when background video call
+               that is transmitting static image is downgraded to Rx or to voice */
+            mVideoCall.setPauseImage(null);
+        }
+
         updateCameraSelection(call);
 
         if (isVideoCall) {
@@ -1061,7 +1072,12 @@ public class VideoCallPresenter extends Presenter<VideoCallPresenter.VideoCallUi
         Log.v(this, "showVideoUi : showIncoming = " + showIncomingVideo + " showOutgoing = "
                 + showOutgoingVideo + " shallTransmitStaticImage = " + shallTransmitStaticImage());
         if (showIncomingVideo || showOutgoingVideo) {
-            ui.showVideoViews(showOutgoingVideo && !shallTransmitStaticImage(), showIncomingVideo);
+            if (QtiCallUtils.shallShowStaticImageUi(mContext)) {
+                ui.showVideoViews(showOutgoingVideo && !shallTransmitStaticImage(),
+                        showIncomingVideo);
+            } else {
+                ui.showVideoViews(showOutgoingVideo, showIncomingVideo);
+            }
 
             boolean hidePreview = shallHidePreview(isConf, videoState);
             Log.v(this, "showVideoUi, hidePreview = " + hidePreview);
@@ -1071,7 +1087,9 @@ public class VideoCallPresenter extends Presenter<VideoCallPresenter.VideoCallUi
 
             if (showOutgoingVideo) {
                 setPreviewSize(mDeviceOrientation, mPreviewAspectRatio);
-                maybeLoadPreConfiguredImageAsync();
+                if (QtiCallUtils.shallShowStaticImageUi(mContext)) {
+                    maybeLoadPreConfiguredImageAsync();
+                }
             }
 
             if (isVideoReceptionEnabled && !shallTransmitStaticImage()) {
@@ -1148,9 +1166,18 @@ public class VideoCallPresenter extends Presenter<VideoCallPresenter.VideoCallUi
 
         mIsInBackground = !showing;
 
+        if (!QtiCallUtils.shallShowStaticImageUi(mContext)) {
+            sShallTransmitStaticImage = sUseDefaultImage = mIsInBackground;
+        }
+
         if (mPrimaryCall == null || !VideoUtils.isActiveVideoCall(mPrimaryCall)) {
             Log.w(this, "onUiShowing, received for non-active video call");
             return;
+        }
+
+        if (!QtiCallUtils.shallShowStaticImageUi(mContext) &&
+            VideoUtils.isTransmissionEnabled(mPrimaryCall)) {
+            setPauseImage();
         }
 
         if (showing) {


### PR DESCRIPTION
1. Send static image when user puts the active video call
   in background
2. Unset the static image when UE come back to foreground
   i.e. when multitasking ends.
3. Unset the static image when Tx is disabled for the video call
   for eg. when background video call that is transmitting static
   image is downgraded to Rx or to voice
4. If respective static image UI config is disabled:
       i. Do not show static image in preview window
       ii. Do not show hide me button in active call screen

Change-Id: Ic117370044dd043dad528219d8a780dfdb5415ee
CRs-Fixed: 1107225